### PR TITLE
[FEAT] auth endpoint에 유저 정보 등록 상태 확인 필드 추가

### DIFF
--- a/backend/src/dto/auth/login-response.dto.ts
+++ b/backend/src/dto/auth/login-response.dto.ts
@@ -1,10 +1,22 @@
-import { IsEmail } from 'class-validator';
+import { IsBoolean, IsEmail } from 'class-validator';
 
 export class LoginResponseDto {
   @IsEmail()
   email: string;
 
-  constructor(email: string) {
+  @IsBoolean()
+  hasProfile: boolean;
+
+  @IsBoolean()
+  hasLoveLanguage: boolean;
+
+  @IsBoolean()
+  hasPersonality: boolean;
+
+  constructor(email: string, hasProfile: boolean = false, hasLoveLanguage: boolean = false, hasPersonality: boolean = false) {
     this.email = email;
+    this.hasProfile = hasProfile;
+    this.hasLoveLanguage = hasLoveLanguage;
+    this.hasPersonality = hasPersonality;
   }
 }

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -32,7 +32,7 @@ export class AuthController {
     @Body() dto: RegisterRequestDto,
     @Res({ passthrough: true }) res: Response,
   ) {
-    const { sessionId } = await this.authService.registerAndLogin(dto);
+    const { sessionId, userId } = await this.authService.registerAndLogin(dto);
 
     // auto login after register
     res.cookie('session_id', sessionId, {
@@ -42,8 +42,11 @@ export class AuthController {
       path: '/',
     });
 
+    // Check if user has profile, personality, and love language data
+    const { hasProfile, hasPersonality, hasLoveLanguage } = await this.authService.checkUserDataStatus(userId);
+
     // use login response dto bcs auto login after register
-    return new LoginResponseDto(dto.email);
+    return new LoginResponseDto(dto.email, hasProfile, hasLoveLanguage, hasPersonality);
   }
 
   /**
@@ -73,7 +76,7 @@ export class AuthController {
       );
     }
 
-    const { sessionId } = await this.authService.login(dto.email, dto.password);
+    const { sessionId, userId } = await this.authService.login(dto.email, dto.password);
 
     res.cookie('session_id', sessionId, {
       httpOnly: true,
@@ -82,7 +85,10 @@ export class AuthController {
       path: '/',
     });
 
-    return new LoginResponseDto(dto.email);
+    // Check if user has profile, personality, and love language data
+    const { hasProfile, hasPersonality, hasLoveLanguage } = await this.authService.checkUserDataStatus(userId);
+
+    return new LoginResponseDto(dto.email, hasProfile, hasLoveLanguage, hasPersonality);
   }
 
   /**

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -47,10 +47,10 @@ export class AuthService {
       `session:${sessionId}`,
       JSON.stringify({ id: createdUser.id, email: dto.email }),
     );
-    return { sessionId };
+    return { sessionId, userId: createdUser.id };
   }
 
-  async login(email: string, password: string): Promise<{ sessionId: string }> {
+  async login(email: string, password: string): Promise<{ sessionId: string, userId: number }> {
     const user = await this.prisma.user.findUnique({
       where: { email },
     });
@@ -67,7 +67,7 @@ export class AuthService {
       `session:${sessionId}`,
       JSON.stringify({ id: user.id, email: user.email }),
     );
-    return { sessionId };
+    return { sessionId, userId: user.id };
   }
 
   async logout(sessionId: string): Promise<void> {
@@ -83,5 +83,34 @@ export class AuthService {
 
     // Session exists, proceed with logout
     await this.redis.del(sessionKey);
+  }
+
+  /**
+   * Check if a user has profile, personality, and love language data
+   * 
+   * @param userId - The ID of the user to check
+   * @returns Object with boolean flags indicating whether each type of data exists
+   */
+  async checkUserDataStatus(userId: number): Promise<{ hasProfile: boolean, hasPersonality: boolean, hasLoveLanguage: boolean }> {
+    // Check if user has profile data
+    const profile = await this.prisma.userProfile.findUnique({
+      where: { user_id: userId },
+    });
+
+    // Check if user has personality data
+    const personality = await this.prisma.userPersonality.findUnique({
+      where: { user_id: userId },
+    });
+
+    // Check if user has love language data
+    const loveLanguage = await this.prisma.userLoveLanguage.findUnique({
+      where: { user_id: userId },
+    });
+
+    return {
+      hasProfile: !!profile,
+      hasPersonality: !!personality,
+      hasLoveLanguage: !!loveLanguage,
+    };
   }
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -92,21 +92,12 @@ export class AuthService {
    * @returns Object with boolean flags indicating whether each type of data exists
    */
   async checkUserDataStatus(userId: number): Promise<{ hasProfile: boolean, hasPersonality: boolean, hasLoveLanguage: boolean }> {
-    // Check if user has profile data
-    const profile = await this.prisma.userProfile.findUnique({
-      where: { user_id: userId },
-    });
-
-    // Check if user has personality data
-    const personality = await this.prisma.userPersonality.findUnique({
-      where: { user_id: userId },
-    });
-
-    // Check if user has love language data
-    const loveLanguage = await this.prisma.userLoveLanguage.findUnique({
-      where: { user_id: userId },
-    });
-
+    // Execute all findUnique calls in parallel
+    const [profile, personality, loveLanguage] = await Promise.all([
+      this.prisma.userProfile.findUnique({ where: { user_id: userId } }),
+      this.prisma.userPersonality.findUnique({ where: { user_id: userId } }),
+      this.prisma.userLoveLanguage.findUnique({ where: { user_id: userId } }),
+    ]);
     return {
       hasProfile: !!profile,
       hasPersonality: !!personality,


### PR DESCRIPTION
# Pull Request

## What changed?
Added fields to login and register responses to indicate whether a user has completed their profile, love language, and personality information. This enhancement allows the frontend to immediately determine what user data is available after login or registration.

Fixes #N/A

##  Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Tested by:

Verifying login and register endpoints return the new fields
Checking that the fields correctly reflect the existence of user data
Testing with both new and existing users to ensure proper data status detection

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [ ] Tests pass
- [ ] Documentation updated